### PR TITLE
fix: skip built-in auth check

### DIFF
--- a/handler/base.ts
+++ b/handler/base.ts
@@ -44,6 +44,7 @@ export class ApiInfoHandler extends Handler {
 
 function CCSMixin<TBase extends new (...args: any[]) => HandlerCommon<Context>>(Base: TBase) {
     return class CCSBase extends Base {
+        public noCheckPermView = true;
         public eventManager = new EventFeedManager(this.ctx);
         public adapter = new CCSAdapter();
 


### PR DESCRIPTION
To avoid 403 when has no permission to hydro system